### PR TITLE
SRE-887 Add SNS message attributes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       - id: check-ast
       - id: check-json
       - id: check-merge-conflict
-      - id: check-yaml
       - id: debug-statements
       - id: detect-private-key
       - id: fix-encoding-pragma

--- a/clamav.py
+++ b/clamav.py
@@ -194,7 +194,14 @@ def scan_file(path):
     av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
     print("Starting clamdscan of %s." % path)
     av_proc = subprocess.Popen(
-        [CLAMDSCAN_PATH, "-v", "--stdout", "--config-file", "%s/scan.conf" % CLAMAVLIB_PATH, path],
+        [
+            CLAMDSCAN_PATH,
+            "-v",
+            "--stdout",
+            "--config-file",
+            "%s/scan.conf" % CLAMAVLIB_PATH,
+            path,
+        ],
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         env=av_env,
@@ -225,6 +232,7 @@ def scan_file(path):
         print(msg)
         raise Exception(msg)
 
+
 def is_clamd_running():
     print("Checking if clamd is running on %s" % CLAMD_SOCKET)
 
@@ -232,7 +240,7 @@ def is_clamd_running():
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
             s.settimeout(10)
             s.connect(CLAMD_SOCKET)
-            s.send(b'PING')
+            s.send(b"PING")
             try:
                 data = s.recv(32)
             except (socket.timeout, socket.error) as e:
@@ -240,10 +248,11 @@ def is_clamd_running():
                 return False
 
         print("Received %s in response to PING" % repr(data))
-        return data == b'PONG\n'
+        return data == b"PONG\n"
 
     print("Clamd is not running on %s" % CLAMD_SOCKET)
     return False
+
 
 def start_clamd_daemon():
     s3 = boto3.resource("s3")

--- a/scan.py
+++ b/scan.py
@@ -24,8 +24,6 @@ import boto3
 
 import clamav
 import metrics
-from common import AV_DEFINITION_S3_BUCKET
-from common import AV_DEFINITION_S3_PREFIX
 from common import AV_DELETE_INFECTED_FILES
 from common import AV_PROCESS_ORIGINAL_VERSION_ONLY
 from common import AV_SCAN_START_METADATA
@@ -43,6 +41,7 @@ from common import get_timestamp
 
 
 clamd_pid = None
+
 
 def event_object(event, event_source="s3"):
 
@@ -165,6 +164,10 @@ def sns_start_scan(sns_client, s3_object, scan_start_sns_arn, timestamp):
         TargetArn=scan_start_sns_arn,
         Message=json.dumps({"default": json.dumps(message)}),
         MessageStructure="json",
+        MessageAttributes={
+            "bucket": {"DataType": "String", "StringValue": s3_object.bucket_name},
+            "key": {"DataType": "String", "StringValue": s3_object.key},
+        },
     )
 
 
@@ -197,6 +200,8 @@ def sns_scan_results(
                 "DataType": "String",
                 "StringValue": scan_signature,
             },
+            "bucket": {"DataType": "String", "StringValue": s3_object.bucket_name},
+            "key": {"DataType": "String", "StringValue": s3_object.key},
         },
     )
 

--- a/scan_test.py
+++ b/scan_test.py
@@ -246,6 +246,10 @@ class TestScan(unittest.TestCase):
             "TargetArn": sns_arn,
             "Message": json.dumps({"default": json.dumps(message)}),
             "MessageStructure": "json",
+            "MessageAttributes": {
+                "bucket": {"DataType": "String", "StringValue": self.s3_bucket_name},
+                "key": {"DataType": "String", "StringValue": self.s3_key_name},
+            },
         }
         sns_stubber.add_response("publish", publish_response, publish_expected_params)
 
@@ -383,6 +387,8 @@ class TestScan(unittest.TestCase):
             "MessageAttributes": {
                 "av-status": {"DataType": "String", "StringValue": scan_result},
                 "av-signature": {"DataType": "String", "StringValue": scan_signature},
+                "bucket": {"DataType": "String", "StringValue": self.s3_bucket_name},
+                "key": {"DataType": "String", "StringValue": self.s3_key_name},
             },
             "MessageStructure": "json",
         }


### PR DESCRIPTION
If multiple subscribers are subscribed to the SNS topic, all of them receive all messages, regardless of whether they need those messages.

Adding message attributes to SNS messages enables defining Subscription Filter policies that help routing the messages to relevant subscribers